### PR TITLE
Fix waitUntilMappedPortReachable host resolution

### DIFF
--- a/src/TestContainers.hs
+++ b/src/TestContainers.hs
@@ -91,8 +91,8 @@ module TestContainers
 
     -- * Misc. Docker functions
 
-  , dockerVersion
-  , isDockerForDesktop
+  , dockerHostOs
+  , isDockerOnLinux
 
     -- * Predefined Docker images
 
@@ -108,5 +108,3 @@ module TestContainers
 
 import           TestContainers.Docker as M
 import           TestContainers.Image  as M
-
-import           Data.Function         as M ((&))


### PR DESCRIPTION
Current master does not allow to get the IP, I have just reverted 83d0541c41d229087ce55b98340001210984f24f and use the local IP address which is the one we use for port exposition for the moment.