### PR TITLE
Expose network option

### DIFF
--- a/src/TestContainers.hs
+++ b/src/TestContainers.hs
@@ -32,6 +32,7 @@ module TestContainers
   , M.setVolumeMounts
   , M.setRm
   , M.setEnv
+  , M.setNetwork
   , M.setLink
   , M.setExpose
   , M.setWaitingFor


### PR DESCRIPTION
This PR introduces the option to specify a network the executed containers will connect to.
This is required in some contexts in which the containers must be connected to a specific networks for specific reasons (access to other containers...).