### PR TITLE
Detect a run within Docker

### DIFF
--- a/src/TestContainers.hs
+++ b/src/TestContainers.hs
@@ -40,6 +40,7 @@ module TestContainers
     -- * Running Docker containers (@docker run@)
 
   , M.Container
+  , M.containerGateway
   , M.containerIp
   , M.containerPort
   , M.containerReleaseKey

--- a/src/TestContainers/Docker.hs
+++ b/src/TestContainers/Docker.hs
@@ -43,6 +43,7 @@ module TestContainers.Docker
 
   , containerId
   , containerImage
+  , containerGateway
   , containerIp
   , containerPort
   , containerReleaseKey

--- a/testcontainers.cabal
+++ b/testcontainers.cabal
@@ -42,7 +42,8 @@ library
                        resourcet            >= 1.2.4 && < 1.3,
                        unliftio-core        >= 0.1.0 && < 0.3,
                        tasty                >= 1.0   && < 1.5,
-                       random               >= 1.2   && < 2
+                       random               >= 1.2   && < 2,
+                       directory            >= 1.3.6 && < 2
 
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
This PR detects whether the running test is running in a Docker container and acts accordingly:

- If the test is not in a Docker container, assume that it is running on the host. Then the usual process takes place: use `localhost` and the mapped port to connect to the container.
- If the test is in a Docker container, assume it is running as a sibling container and that the `docker` command manages the same Docker engine (that's on the user to configure the container properly). Find and use the gateway IP address (which should represent the Docker host) and use the mapped port.

This is required as some CI engine may choose to (or be configured to) run the test in a container. As such, `localhost` won't be usable to connect to the container as it would represent the test container itself.