### PR TITLE
Add waitForHttp

### DIFF
--- a/src/TestContainers.hs
+++ b/src/TestContainers.hs
@@ -78,6 +78,9 @@ module TestContainers
 
   , M.waitUntilMappedPortReachable
 
+    -- ** Wait until the http server responds with a specific status code
+  , M.waitForHttp
+
     -- * Monad
 
   , M.MonadDocker

--- a/src/TestContainers.hs
+++ b/src/TestContainers.hs
@@ -40,9 +40,11 @@ module TestContainers
     -- * Running Docker containers (@docker run@)
 
   , M.Container
+  , M.containerAlias
   , M.containerGateway
   , M.containerIp
   , M.containerPort
+  , M.containerAddress
   , M.containerReleaseKey
   , M.containerImage
 

--- a/test/TestContainers/TastySpec.hs
+++ b/test/TestContainers/TastySpec.hs
@@ -6,8 +6,9 @@ import           Data.Text.Lazy       (isInfixOf)
 import           Test.Tasty
 import           Test.Tasty.HUnit
 import           TestContainers.Tasty (MonadDocker, Pipe (Stdout),
-                                       containerRequest, fromBuildContext, fromTag, redis, run,
-                                       setExpose, setRm, setWaitingFor,
+                                       containerRequest, fromBuildContext,
+                                       fromTag, redis, run, setExpose, setRm,
+                                       setWaitingFor, waitForHttp,
                                        waitForLogLine,
                                        waitUntilMappedPortReachable,
                                        waitUntilTimeout, withContainers, (&))
@@ -24,6 +25,11 @@ containers1 = do
   _rabbitmq <- run $ containerRequest (fromTag "rabbitmq:3.8.4")
     & setRm False
     & setWaitingFor (waitForLogLine Stdout (("completed with" `isInfixOf`)))
+
+  _nginx <- run $ containerRequest (fromTag "nginx:1.23.1-alpine")
+    & setExpose [ 80 ]
+    & setWaitingFor (waitUntilTimeout 30 $
+                      waitForHttp 80 "/" [200])
 
   _test <- run $ containerRequest (fromBuildContext "./test/container1" Nothing)
 

--- a/testcontainers.cabal
+++ b/testcontainers.cabal
@@ -43,7 +43,10 @@ library
                        unliftio-core        >= 0.1.0 && < 0.3,
                        tasty                >= 1.0   && < 1.5,
                        random               >= 1.2   && < 2,
-                       directory            >= 1.3.6 && < 2
+                       directory            >= 1.3.6 && < 2,
+                       http-client          >= 0.5.14 && < 1,
+                       http-types           >= 0.12.3 && < 1,
+                       utf8-string          >= 1.0.1.1 && < 2
 
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
This PR adds the `waitForHttp` which waits until the given container port returns one of the acceptable status codes.

This is required as in some cases, `waitUntilMappedPortReachable` is not enough: the containerized Web container is listening to requests but is actually still not ready to take them.

Some notes regarding this implementation:

- It is limited to `GET` requests. It may be interesting to be more flexible on the request in the future.
- A fresh new `Manager` is created for each port to be tested, which may be kind of wasteful.
- The `HttpException` is not traced as-is as there is no instance for `Eq HttpException`, and `Trace` requires it. A `String` is used instead. Not ideal, but might be enough for tests? Removing `Eq` for `Trace` would be a breaking change.
- New dependencies that may not be useful for everyone is introduced.